### PR TITLE
Use propper locking in start script

### DIFF
--- a/script.steam.launcher/resources/scripts/steam-launch.sh
+++ b/script.steam.launcher/resources/scripts/steam-launch.sh
@@ -122,7 +122,8 @@ while [[ $(wmctrl -l | grep "$STEAM_WIN_ID") ]] ; do
   sleep 0.5
 done
 
-if mkdir /var/lock/.steam-launcher.exclusivelock ; then
+(
+  flock -x -n 200 || exit
 
   if [[ $6 != false ]] ; then
     "$6"
@@ -141,10 +142,8 @@ if mkdir /var/lock/.steam-launcher.exclusivelock ; then
     fi
   fi
 
-  rmdir /var/lock/.steam-launcher.exclusivelock
-else
-  exit
-fi
+  flock -u 200
+) 200>/tmp/.steam-launcher.exclusivelock
 
 #####################################
         ;;


### PR DESCRIPTION
Also don't try to write to /var/lock, which is not writeable on some distributions.
