### PR TITLE
Close all file descriptors before spawning steam launcher

### DIFF
--- a/script.steam.launcher/default.py
+++ b/script.steam.launcher/default.py
@@ -313,7 +313,7 @@ def launchSteam():
 		cmd = '"%s" "%s" "%s" "%s" "%s" "%s" "%s"' % (steamlauncher, steamLinux, xbmcLinux, quitXbmcSetting, xbmcPortable, preScript, postScript)
 	try:
 		log('attempting to launch: %s' % cmd)
-		subprocess.Popen(cmd, shell=True)
+		subprocess.Popen(cmd, shell=True, close_fds=True)
 		xbmcBusyDialog()
 	except:
 		log('ERROR: failed to launch: %s' % cmd)


### PR DESCRIPTION
As mentioned in the [XBMC forums](http://forum.xbmc.org/showthread.php?tid=157499&pid=1803130#pid1803130), this should fix all problems regarding the "port 8080 is still open" issue.
